### PR TITLE
fix: indent annotation to squash error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - NET_ADMIN
       # SYS_MODULE might not be needed with a 5.6+ kernel?
       - SYS_MODULE
-    # Mounting the tun device may be necessary for userspace implementations
+      # Mounting the tun device may be necessary for userspace implementations
     devices:
       - /dev/net/tun:/dev/net/tun
     environment:
@@ -30,7 +30,7 @@ services:
       - net.ipv6.conf.default.disable_ipv6=1
       - net.ipv6.conf.all.disable_ipv6=1
       - net.ipv6.conf.lo.disable_ipv6=1
-    # The container has no recovery logic. Use a healthcheck to catch disconnects.
+      # The container has no recovery logic. Use a healthcheck to catch disconnects.
     healthcheck:
       test: ping -c 1 www.google.com || exit 1
       interval: 30s


### PR DESCRIPTION
Fixed docker-compose.yaml formatting error regarding annotation indentation.