### PR TITLE
add: link in readme title for dockerhub ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-wireguard
+# [docker-wireguard](https://github.com/pyunramura/docker-wireguard)
 
 [![Build](https://github.com/pyunramura/docker-wireguard/actions/workflows/main.yaml/badge.svg?branch=main)](https://github.com/pyunramura/docker-wireguard/actions/workflows/main.yaml)
 


### PR DESCRIPTION
Added a link to the repo in the title. Since it's synced to dockerhub, it will make it easier to link to the repo for those discovering it on dockerhub.