### PR TITLE
mod: update alpine base image to 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.15
 RUN apk add --no-cache \
     bash=5.1.8-r0 \
     ip6tables=1.8.7-r1 \
@@ -13,7 +13,6 @@ ENV LOCAL_NETWORK= \
     WG_USERSPACE=0 \
     PEER_PORT=51820
 RUN sed -i 's/cmd sysctl.*/set +e \&\& sysctl -q net.ipv4.conf.all.src_valid_mark=1 \&\& set -e/' /usr/bin/wg-quick
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing wireguard-go=0.0.20210212-r0
 WORKDIR /app
 COPY run /app
 RUN chmod 755 /app/run


### PR DESCRIPTION
del: separate wireguard-go package, included in wg-tools
testing if this resolves issue with dockerfile-updater action, as suggested package versions were out of date on alpine 3.13 but are current on alpine 3.15